### PR TITLE
Fix menu scroll position

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -9,3 +9,6 @@ application.register("color-theme", ColorThemeController)
 
 import LottieController from "./lottie_controller"
 application.register("lottie", LottieController)
+
+import SidebarMenuController from "./sidebar_menu_controller"
+application.register("sidebar-menu", SidebarMenuController)

--- a/app/javascript/controllers/sidebar_menu_controller.js
+++ b/app/javascript/controllers/sidebar_menu_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="sidebar-menu"
+export default class extends Controller {
+  connect() {
+    window.addEventListener("turbo:before-visit", () => {
+      localStorage.setItem("menuScrollPositon", this.element.scrollTop);
+    });
+
+    window.addEventListener("turbo:load", () => {
+      this.element.scrollTop = localStorage.getItem("menuScrollPositon") || 0;
+    });
+  }
+}

--- a/app/views/components/shared/sidebar.rb
+++ b/app/views/components/shared/sidebar.rb
@@ -4,22 +4,10 @@ class Shared::Sidebar < ApplicationComponent
   def view_template
     aside(class: "fixed top-14 z-30 -ml-2 hidden h-[calc(100vh-3.5rem)] w-full shrink-0 md:sticky md:block") do
       div(class: "relative overflow-hidden h-full py-6 pl-8 pr-6 lg:py-8", style: "position:relative;--radix-scroll-area-corner-width:0px;--radix-scroll-area-corner-height:0px") do
-        div(id: "sidebar-menu", class: "h-full w-full rounded-[inherit]", style: "overflow: hidden scroll;") do
+        div(class: "h-full w-full rounded-[inherit]", style: "overflow: hidden scroll;", data_controller: "sidebar-menu") do
           render Shared::Menu.new
         end
       end
-    end
-
-    script do
-      safe <<-JS
-        window.addEventListener("turbo:before-visit", () => {
-          localStorage.setItem("menuScrollPositon", document.getElementById("sidebar-menu").scrollTop);
-        });
-
-        window.addEventListener("turbo:load", () => {
-          document.getElementById("sidebar-menu").scrollTop = localStorage.getItem("menuScrollPositon") || 0;
-        });
-      JS
     end
   end
 end

--- a/app/views/components/shared/sidebar.rb
+++ b/app/views/components/shared/sidebar.rb
@@ -4,10 +4,22 @@ class Shared::Sidebar < ApplicationComponent
   def view_template
     aside(class: "fixed top-14 z-30 -ml-2 hidden h-[calc(100vh-3.5rem)] w-full shrink-0 md:sticky md:block") do
       div(class: "relative overflow-hidden h-full py-6 pl-8 pr-6 lg:py-8", style: "position:relative;--radix-scroll-area-corner-width:0px;--radix-scroll-area-corner-height:0px") do
-        div(class: "h-full w-full rounded-[inherit]", style: "overflow: hidden scroll;") do
+        div(id: "sidebar-menu", class: "h-full w-full rounded-[inherit]", style: "overflow: hidden scroll;") do
           render Shared::Menu.new
         end
       end
+    end
+
+    script do
+      safe <<-JS
+        window.addEventListener("turbo:before-visit", () => {
+          localStorage.setItem("menuScrollPositon", document.getElementById("sidebar-menu").scrollTop);
+        });
+
+        window.addEventListener("turbo:load", () => {
+          document.getElementById("sidebar-menu").scrollTop = localStorage.getItem("menuScrollPositon") || 0;
+        });
+      JS
     end
   end
 end

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": "true",
   "dependencies": {
     "@hotwired/stimulus": "3.2.2",
-    "@hotwired/turbo-rails": "8.0.5",
+    "@hotwired/turbo-rails": "8.0.12",
     "autoprefixer": "10.4.19",
     "chart.js": "4.4.3",
     "class-variance-authority": "0.7.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -159,15 +159,15 @@
   resolved "https://registry.yarnpkg.com/@hotwired/stimulus/-/stimulus-3.2.2.tgz#071aab59c600fed95b97939e605ff261a4251608"
   integrity sha512-eGeIqNOQpXoPAIP7tC1+1Yc1yl1xnwYqg+3mzqxyrbE5pg5YFBZcA6YoTiByJB6DKAEsiWtl6tjTJS4IYtbB7A==
 
-"@hotwired/turbo-rails@8.0.5":
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-8.0.5.tgz#18c2f0e4f7f952307650308590edf5eb9544b0d3"
-  integrity sha512-1A9G9u28IRAl0C57z8Ka3AhNPyJdwfOrbjr+ABZk2ZEUw2QO7cJ0pgs77asUj2E/tzn1PgrxrSVu24W+1Q5uBA==
+"@hotwired/turbo-rails@8.0.12":
+  version "8.0.12"
+  resolved "https://registry.yarnpkg.com/@hotwired/turbo-rails/-/turbo-rails-8.0.12.tgz#6f1a2661122c0a2bf717f3bc68b5106638798c89"
+  integrity sha512-ZXwu9ez+Gd4RQNeHIitqOQgi/LyqY8J4JqsUN0nnYiZDBRq7IreeFdMbz29VdJpIsmYqwooE4cFzPU7QvJkQkA==
   dependencies:
-    "@hotwired/turbo" "^8.0.5"
+    "@hotwired/turbo" "^8.0.12"
     "@rails/actioncable" "^7.0"
 
-"@hotwired/turbo@^8.0.5":
+"@hotwired/turbo@^8.0.12":
   version "8.0.12"
   resolved "https://registry.yarnpkg.com/@hotwired/turbo/-/turbo-8.0.12.tgz#50aa8345d7f62402680c6d2d9814660761837001"
   integrity sha512-l3BiQRkD7qrnQv6ms6sqPLczvwbQpXt5iAVwjDvX0iumrz6yEonQkNAzNjeDX25/OJMFDTxpHjkJZHGpM9ikWw==


### PR DESCRIPTION
At first I thought it was a problem with turbo, but I think there is an incompatibility with sticky/overflow/fixed styles. I tried using `data_turbo_action: "replace"` on menu links to work with morph/preserve turbo options, but it didn't work. The solution I found was storing scroll position on localstorage before leaving page and get scroll position after visit.

Before:

https://github.com/user-attachments/assets/03451e11-96b3-4c6d-bfbe-1a47e736aaf8

After:

https://github.com/user-attachments/assets/afd0a4ce-9f3b-4689-85de-826f00896595



