### PR TITLE
Remove referenced components list

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,34 +1,6 @@
+require "rubygems"
+
 module ApplicationHelper
-  def component_references(component, code_example = nil, use_component_files = false)
-    return [] unless code_example
-
-    calls = []
-    Prism.parse(code_example).value.accept(MethodCallFinder.new(calls))
-    calls_set = Set.new(calls.map(&:to_s))
-    descendants = Phlex::HTML.descendants.map { |d| d.to_s.gsub(/^RubyUI::/, "") }
-    component_names = descendants.select { |d| calls_set.include?(d) }
-
-    # component_names = code_example.scan(/(?<=^|\s)#{component}\w*/).uniq
-
-    component_names.map do |name|
-      Docs::ComponentStruct.new(
-        name: name,
-        source: "lib/ruby_ui/#{camel_to_snake(component)}/#{camel_to_snake(name)}.rb",
-        built_using: :phlex
-      )
-    end
-
-    # component_names.push(
-    #   Docs::ComponentStruct.new(
-    #     name: "ComboboxController",
-    #     source: "https://github.com/PhlexUI/phlex_ui_stimulus/blob/main/controllers/command_controller.js",
-    #     built_using: :stimulus
-    #   )
-    # )
-  end
-
-  require "rubygems"
-
   def component_files(component, gem_name = "ruby_ui")
     # Find the gem specification
     gem_spec = Gem::Specification.find_by_name(gem_name)

--- a/app/views/components/docs/components_table.rb
+++ b/app/views/components/docs/components_table.rb
@@ -1,40 +1,14 @@
 # frozen_string_literal: true
 
 class Docs::ComponentsTable < ApplicationComponent
-  def initialize(components, file_components = nil)
-    @components = components.sort_by { |component| [component.built_using, component.name] }
-    @file_components = file_components.sort_by { |component| [component.built_using, component.name] } if file_components
+  def initialize(component_files)
+    @component_files = component_files.sort_by { |component| [component.built_using, component.name] }
   end
 
   def view_template
     Heading(level: 2) { "Components" }
 
-    Tabs(default_value: "account", class: "") do
-      TabsList do
-        TabsTrigger(value: "components") { "Components Referenced" }
-        TabsTrigger(value: "file-components") { "Component files" }
-      end
-      TabsContent(value: "components") do
-        div(class: "rounded-lg border p-6 space-y-4 bg-background text-foreground") do
-          div(class: "space-y-0") do
-            component_table_view(@components)
-          end
-        end
-      end
-      if @file_components
-        TabsContent(value: "file-components") do
-          div(class: "rounded-lg border p-6 space-y-4 bg-background text-foreground") do
-            div do
-              if @file_components.present?
-                component_table_view(@file_components)
-              else
-                Text { "No components for this page" }
-              end
-            end
-          end
-        end
-      end
-    end
+    component_table_view(@component_files)
   end
 
   private

--- a/app/views/docs/accordion_view.rb
+++ b/app/views/docs/accordion_view.rb
@@ -45,7 +45,7 @@ class Docs::AccordionView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, @@code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/alert_dialog_view.rb
+++ b/app/views/docs/alert_dialog_view.rb
@@ -27,7 +27,7 @@ class Docs::AlertDialogView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/alert_view.rb
+++ b/app/views/docs/alert_view.rb
@@ -57,7 +57,7 @@ class Docs::AlertView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 

--- a/app/views/docs/aspect_ratio_view.rb
+++ b/app/views/docs/aspect_ratio_view.rb
@@ -60,7 +60,7 @@ class Docs::AspectRatioView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/avatar_view.rb
+++ b/app/views/docs/avatar_view.rb
@@ -84,7 +84,7 @@ class Docs::AvatarView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/badge_view.rb
+++ b/app/views/docs/badge_view.rb
@@ -70,7 +70,7 @@ class Docs::BadgeView < ApplicationView
       end
 
       # components
-      render Docs::ComponentsTable.new(component_references("Badge", Docs::VisualCodeExample.collected_code), component_files("Badge"))
+      render Docs::ComponentsTable.new(component_files("Badge"))
     end
   end
 end

--- a/app/views/docs/button_view.rb
+++ b/app/views/docs/button_view.rb
@@ -51,7 +51,7 @@ class Docs::ButtonView < ApplicationView
 
       render Docs::VisualCodeExample.new(title: "Icon", context: self) do
         <<~RUBY
-          Button(variant: :outline, icon: true) do 
+          Button(variant: :outline, icon: true) do
             svg(
               xmlns: "http://www.w3.org/2000/svg",
               viewbox: "0 0 20 20",
@@ -71,7 +71,7 @@ class Docs::ButtonView < ApplicationView
 
       render Docs::VisualCodeExample.new(title: "With Icon", context: self) do
         <<~RUBY
-          Button(variant: :primary) do 
+          Button(variant: :primary) do
             svg(
               xmlns: "http://www.w3.org/2000/svg",
               fill: "none",
@@ -94,7 +94,7 @@ class Docs::ButtonView < ApplicationView
 
       render Docs::VisualCodeExample.new(title: "With Icon", context: self) do
         <<~RUBY
-          Button(variant: :primary, disabled: true) do 
+          Button(variant: :primary, disabled: true) do
             svg(
               xmlns: "http://www.w3.org/2000/svg",
               viewbox: "0 0 20 20",
@@ -115,13 +115,13 @@ class Docs::ButtonView < ApplicationView
 
       render Docs::VisualCodeExample.new(title: "Submit", context: self) do
         <<~RUBY
-          Button(variant: :primary, type: :submit) do 
+          Button(variant: :primary, type: :submit) do
             span { "Submit application" }
           end
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references("Button", Docs::VisualCodeExample.collected_code), component_files("Button"))
+      render Docs::ComponentsTable.new(component_files("Button"))
     end
   end
 end

--- a/app/views/docs/calendar_view.rb
+++ b/app/views/docs/calendar_view.rb
@@ -26,7 +26,7 @@ class Docs::CalendarView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/card_view.rb
+++ b/app/views/docs/card_view.rb
@@ -74,7 +74,7 @@ class Docs::CardView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 

--- a/app/views/docs/checkbox_group_view.rb
+++ b/app/views/docs/checkbox_group_view.rb
@@ -2,7 +2,7 @@
 
 class Docs::CheckboxGroupView < ApplicationView
   def view_template
-    component = "Checkbox Group"
+    component = "Checkbox"
 
     div(class: "max-w-2xl mx-auto w-full py-10 space-y-10") do
       render Docs::Header.new(title: "Checkbox Group", description: "A control that allows the user to toggle between checked and not checked.")
@@ -71,7 +71,7 @@ class Docs::CheckboxGroupView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/checkbox_view.rb
+++ b/app/views/docs/checkbox_view.rb
@@ -33,7 +33,7 @@ class Docs::CheckboxView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/clipboard_view.rb
+++ b/app/views/docs/clipboard_view.rb
@@ -22,7 +22,7 @@ class Docs::ClipboardView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/codeblock_view.rb
+++ b/app/views/docs/codeblock_view.rb
@@ -10,7 +10,7 @@ class Docs::CodeblockView < ApplicationView
 
       render Docs::VisualCodeExample.new(title: "With clipboard", context: self) do
         <<~RUBY
-          code = <<~CODE 
+          code = <<~CODE
               def hello_world
                 puts "Hello, world!"
               end
@@ -23,7 +23,7 @@ class Docs::CodeblockView < ApplicationView
 
       render Docs::VisualCodeExample.new(title: "Without clipboard", context: self) do
         <<~RUBY
-          code = <<~CODE 
+          code = <<~CODE
               def hello_world
                 puts "Hello, world!"
               end
@@ -36,7 +36,7 @@ class Docs::CodeblockView < ApplicationView
 
       render Docs::VisualCodeExample.new(title: "Custom message", description: "Copy the code to see the message", context: self) do
         <<~RUBY
-          code = <<~CODE 
+          code = <<~CODE
               def hello_world
                 puts "Hello, world!"
               end
@@ -47,7 +47,7 @@ class Docs::CodeblockView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/collapsible_view.rb
+++ b/app/views/docs/collapsible_view.rb
@@ -70,7 +70,7 @@ class Docs::CollapsibleView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 

--- a/app/views/docs/combobox_view.rb
+++ b/app/views/docs/combobox_view.rb
@@ -53,7 +53,7 @@ class Docs::ComboboxView < ApplicationView
           end
         RUBY
       end
-      render Docs::ComponentsTable.new(component_references(component, @@code_example), component_files("Combobox"))
+      render Docs::ComponentsTable.new(component_files("Combobox"))
     end
   end
 end

--- a/app/views/docs/command_view.rb
+++ b/app/views/docs/command_view.rb
@@ -93,7 +93,7 @@ class Docs::CommandView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 

--- a/app/views/docs/context_menu_view.rb
+++ b/app/views/docs/context_menu_view.rb
@@ -77,7 +77,7 @@ class Docs::ContextMenuView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/date_picker_view.rb
+++ b/app/views/docs/date_picker_view.rb
@@ -2,7 +2,7 @@
 
 class Docs::DatePickerView < ApplicationView
   def view_template
-    component = "Date Picker"
+    component = "DatePicker"
 
     div(class: "max-w-2xl mx-auto w-full py-10 space-y-10") do
       render Docs::Header.new(title: "Date Picker", description: "A date picker component with input.")
@@ -27,7 +27,7 @@ class Docs::DatePickerView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/dialog_view.rb
+++ b/app/views/docs/dialog_view.rb
@@ -97,7 +97,7 @@ class Docs::DialogView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/dropdown_menu_view.rb
+++ b/app/views/docs/dropdown_menu_view.rb
@@ -222,7 +222,7 @@ class Docs::DropdownMenuView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/form_view.rb
+++ b/app/views/docs/form_view.rb
@@ -140,7 +140,7 @@ class Docs::FormView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/hover_card_view.rb
+++ b/app/views/docs/hover_card_view.rb
@@ -52,7 +52,7 @@ class Docs::HoverCardView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 

--- a/app/views/docs/input_view.rb
+++ b/app/views/docs/input_view.rb
@@ -52,7 +52,7 @@ class Docs::InputView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/link_view.rb
+++ b/app/views/docs/link_view.rb
@@ -35,7 +35,7 @@ class Docs::LinkView < ApplicationView
 
       render Docs::VisualCodeExample.new(title: "Icon", description: "This is the icon variant of a Link", context: self) do
         <<~RUBY
-          Link(href: "#", variant: :outline, icon: true) do 
+          Link(href: "#", variant: :outline, icon: true) do
             chevron_icon
           end
         RUBY
@@ -43,7 +43,7 @@ class Docs::LinkView < ApplicationView
 
       render Docs::VisualCodeExample.new(title: "With Icon", description: "This is the primary variant of a Link with an icon", context: self) do
         <<~RUBY
-          Link(href: "#", variant: :primary) do 
+          Link(href: "#", variant: :primary) do
             email_icon
             span { "Login with Email" }
           end
@@ -56,7 +56,7 @@ class Docs::LinkView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 

--- a/app/views/docs/masked_input_view.rb
+++ b/app/views/docs/masked_input_view.rb
@@ -39,7 +39,7 @@ class Docs::MaskedInputView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/pagination_view.rb
+++ b/app/views/docs/pagination_view.rb
@@ -43,7 +43,7 @@ class Docs::PaginationView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 

--- a/app/views/docs/popover_view.rb
+++ b/app/views/docs/popover_view.rb
@@ -963,7 +963,7 @@ class Docs::PopoverView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/select_view.rb
+++ b/app/views/docs/select_view.rb
@@ -31,7 +31,7 @@ class Docs::SelectView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/sheet_view.rb
+++ b/app/views/docs/sheet_view.rb
@@ -68,7 +68,7 @@ class Docs::SheetView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/shortcut_key_view.rb
+++ b/app/views/docs/shortcut_key_view.rb
@@ -21,7 +21,7 @@ class Docs::ShortcutKeyView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/table_view.rb
+++ b/app/views/docs/table_view.rb
@@ -44,7 +44,7 @@ class Docs::TableView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 

--- a/app/views/docs/tabs_view.rb
+++ b/app/views/docs/tabs_view.rb
@@ -107,7 +107,7 @@ class Docs::TabsView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 

--- a/app/views/docs/textarea_view.rb
+++ b/app/views/docs/textarea_view.rb
@@ -39,6 +39,6 @@ class Docs::TextareaView < ApplicationView
       end
     end
 
-    render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+    render Docs::ComponentsTable.new(component_files(component))
   end
 end

--- a/app/views/docs/theme_toggle_view.rb
+++ b/app/views/docs/theme_toggle_view.rb
@@ -63,7 +63,7 @@ class Docs::ThemeToggleView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end

--- a/app/views/docs/tooltip_view.rb
+++ b/app/views/docs/tooltip_view.rb
@@ -24,7 +24,7 @@ class Docs::TooltipView < ApplicationView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 

--- a/app/views/docs/typography_view.rb
+++ b/app/views/docs/typography_view.rb
@@ -99,7 +99,7 @@ class Docs::TypographyView < ComponentView
         RUBY
       end
 
-      render Docs::ComponentsTable.new(component_references(component, Docs::VisualCodeExample.collected_code), component_files(component))
+      render Docs::ComponentsTable.new(component_files(component))
     end
   end
 end


### PR DESCRIPTION
Display only components related to current component page, removing "Referenced components" list.

Before:
<img width="742" alt="Screenshot 2024-11-11 at 17 38 21" src="https://github.com/user-attachments/assets/3f21e70d-c478-4dbe-8ff6-f56c8d936a26">

After:
<img width="768" alt="Screenshot 2024-11-11 at 17 38 27" src="https://github.com/user-attachments/assets/bbd36d99-b61a-4167-b807-cc9bc8763ea9">
