### PR TITLE
Update importmap setup instructions

### DIFF
--- a/app/views/docs/installation/rails_bundler_view.rb
+++ b/app/views/docs/installation/rails_bundler_view.rb
@@ -1,11 +1,6 @@
 # frozen_string_literal: true
 
 class Docs::Installation::RailsBundlerView < ApplicationView
-  def initialize
-    @phlex_rails_link = "https://www.phlex.fun/rails/"
-    @phlex_ui_pro_private_key = ENV["BUNDLE_PHLEXUI__FURY__SITE"]
-  end
-
   def view_template
     div(class: "max-w-2xl mx-auto w-full py-10 space-y-10") do
       render Docs::Header.new(title: "Rails - JS Bundler", description: "How to install RubyUI within a Rails app that employs JS bundling.")
@@ -460,23 +455,6 @@ class Docs::Installation::RailsBundlerView < ApplicationView
         d:
           "M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12zm8.706-1.442c1.146-.573 2.437.463 2.126 1.706l-.709 2.836.042-.02a.75.75 0 01.67 1.34l-.04.022c-1.147.573-2.438-.463-2.127-1.706l.71-2.836-.042.02a.75.75 0 11-.671-1.34l.041-.022zM12 9a.75.75 0 100-1.5.75.75 0 000 1.5z",
         clip_rule: "evenodd"
-      )
-    end
-  end
-
-  def arrow_icon
-    svg(
-      xmlns: "http://www.w3.org/2000/svg",
-      fill: "none",
-      viewbox: "0 0 24 24",
-      stroke_width: "2",
-      stroke: "currentColor",
-      class: "w-4 h-4 ml-1.5 -mr-1"
-    ) do |s|
-      s.path(
-        stroke_linecap: "round",
-        stroke_linejoin: "round",
-        d: "M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75"
       )
     end
   end

--- a/app/views/docs/installation/rails_importmaps_view.rb
+++ b/app/views/docs/installation/rails_importmaps_view.rb
@@ -1,39 +1,44 @@
 # frozen_string_literal: true
 
 class Docs::Installation::RailsImportmapsView < ApplicationView
-  def initialize
-    @phlex_rails_link = "https://www.phlex.fun/rails/"
-    @phlex_ui_pro_private_key = ENV["BUNDLE_PHLEXUI__FURY__SITE"]
-  end
-
   def view_template
     div(class: "max-w-2xl mx-auto w-full py-10 space-y-10") do
-      render Docs::Header.new(title: "Rails - Importmaps", description: "How to install RubyUI within a Rails app that uses Importmaps.")
+      render Docs::Header.new(title: "Rails - Importmap", description: "How to install RubyUI within a Rails app that employs import maps")
 
-      Alert(variant: :warning) do
-        alert_icon
-        AlertTitle { "Tailwind plugins not compatible with importmaps" }
-        AlertDescription { "This means that animation using tailwind-animate plugin will not work. I am thinking of a new way to implement this, most likely with a stimulus controller for animations." }
+      Alert(variant: :info) do
+        AlertTitle { "RubyUI" }
+        AlertDescription { "To take full advantage of RubyUI, the application is expected to be using TailwindCSS and Stimulus" }
       end
 
-      Heading(level: 2, class: "!text-2xl pb-4 border-b") { "Creating a Rails app" }
+      Heading(level: 2, class: "!text-2xl pb-4 border-b") { "Using RubyUI CLI" }
+      Text do
+        "We provide a Ruby gem with useful generators to help you to setup RubyUI components in your apps."
+      end
+
       render Steps::Builder.new do |steps|
         steps.add_step do
           step_container do
-            Text(size: "4", weight: "semibold") { "Generate a new Rails application" }
-            Text do
-              plain "In case you don't have a Rails application set up yet, let's start by generating one. The demo uses importmaps (Rails default). "
-              InlineLink(href: "https://guides.rubyonrails.org/working_with_javascript_in_rails.html#import-maps") { "Read more about Importmaps in Rails here." }
+            Text(size: "4", weight: "semibold") do
+              plain "Add RubyUI gem to your Gemfile"
             end
+
             code = <<~CODE
-              rails new CHANGE_TO_NAME_OF_APP --css=tailwind
+              bundle add ruby_ui --group development --require false
             CODE
             div(class: "w-full") do
               Codeblock(code, syntax: :javascript)
             end
-            Text { "Once that is created, navigate to the app" }
+          end
+        end
+
+        steps.add_step do
+          step_container do
+            Text(size: "4", weight: "semibold") do
+              "Run the install command"
+            end
+
             code = <<~CODE
-              cd CHANGE_TO_NAME_OF_APP
+              rails g ruby_ui:install
             CODE
             div(class: "w-full") do
               Codeblock(code, syntax: :javascript)
@@ -42,92 +47,397 @@ class Docs::Installation::RailsImportmapsView < ApplicationView
         end
       end
 
-      Heading(level: 2, class: "!text-2xl pb-4 border-b") { "Install the gem" }
+      Heading(level: 2, class: "!text-2xl pb-4 border-b") { "Manual" }
+      Text do
+        "You can install the dependencies manually if you prefer"
+      end
       render Steps::Builder.new do |steps|
-        # STEP 1
         steps.add_step do
           step_container do
-            Text(size: "4", weight: "semibold") { "Install Phlex" }
-            Text { "Run the following in the terminal to install phlex for Rails" }
+            Text(size: "4", weight: "semibold") do
+              "Add Phlex Rails to your app"
+            end
+
             code = <<~CODE
-              bundle add phlex-rails
+              bundle add phlex-rails --github phlex-ruby/phlex-rails --branch main
             CODE
             div(class: "w-full") do
               Codeblock(code, syntax: :javascript)
             end
-            Text { "After the gem is installed, run the generator to create necessary files." }
+
+            Alert(variant: :warning) do
+              info_icon
+              AlertTitle { "Phlex compatibility" }
+              AlertDescription { "Note that RubyUI components target Phlex 2, but you can use them with Phlex 1.x as long as you are willing to adapt their code." }
+            end
+          end
+        end
+
+        steps.add_step do
+          step_container do
+            Text(size: "4", weight: "semibold") do
+              "Install Phlex Rails"
+            end
+
             code = <<~CODE
-              bin/rails generate phlex:install
+              bin/rails g phlex:install
             CODE
             div(class: "w-full") do
               Codeblock(code, syntax: :javascript)
             end
-            Text do
-              plain "Refer to the "
-              InlineLink(href: @phlex_rails_link) { "Phlex installation guide for Rails" }
-              plain " for more information."
-            end
           end
         end
-        # STEP 2
+
         steps.add_step do
           step_container do
-            Text(size: "4", weight: "semibold") { "Install RubyUI gem" }
-            Text { "Run the following in the terminal to install the RubyUI Component Library" }
+            Text(size: "4", weight: "semibold") do
+              "Install tailwind_merge"
+            end
+
+            Text do
+              "RubyUI components use tailwind_merge to avoid conflicts between TailwindCSS classes"
+            end
+
             code = <<~CODE
-              bundle add phlex_ui
+              bundle add tailwind_merge
             CODE
-            Codeblock(code, syntax: :javascript)
+            div(class: "w-full") do
+              Codeblock(code, syntax: :javascript)
+            end
           end
         end
-        # STEP 3
+
         steps.add_step do
           step_container do
-            Text(size: "4", weight: "semibold") { "Include RubyUI module" }
-            Text do
-              plain "Include RubyUI module in your "
-              InlineCode(class: "whitespace-nowrap") { "application_component.rb" }
-              plain " file"
+            Text(size: "4", weight: "semibold") do
+              "Create RubyUI initializer"
             end
-            code = <<~CODE
-              class ApplicationComponent < Phlex::HTML
-                include RubyUI
+
+            Text do
+              plain "Add this code to "
+              InlineCode(class: "whitespace-nowrap") { "config/initializers/ruby_ui.rb" }
+            end
+
+            code = <<~RUBY
+              module RubyUI
+                extend Phlex::Kit
               end
-            CODE
-            Codeblock(code, syntax: :ruby)
-          end
-        end
-      end
 
-      # JS INSTALLATION
-      Heading(level: 2, class: "!text-2xl pb-4 border-b") { "Install JS" }
-      js_installation
+              # Allow using RubyUI instead RubyUi
+              Rails.autoloaders.main.inflector.inflect(
+                "ruby_ui" => "RubyUI"
+              )
 
-      # STYLE INSTALLATION
-      Heading(level: 2, class: "!text-2xl pb-4 border-b") { "Install Styles" }
-      render Steps::Builder.new do |steps|
-        # STEP 1
-        steps.add_step do
-          step_container do
-            Text(size: "4", weight: "semibold") { "Install TailwindCSS" }
-            Text do
-              plain "In this guide we have already installed TailwindCSS, however if you have not done this make sure to follow the "
-              InlineLink(href: "https://tailwindcss.com/docs/guides/ruby-on-rails") { "TailwindCSS installation guide" }
+              # Allow using RubyUI::ComponentName instead Components::RubyUI::ComponentName
+              Rails.autoloaders.main.push_dir(
+                "\#{Rails.root}/app/components/ruby_ui", namespace: RubyUI
+              )
+
+              # Allow using RubyUI::ComponentName instead RubyUI::ComponentName::ComponentName
+              Rails.autoloaders.main.collapse(Rails.root.join("app/components/ruby_ui/*"))
+            RUBY
+            div(class: "w-full") do
+              Codeblock(code, syntax: :ruby)
             end
           end
         end
 
-        # STEP 2
         steps.add_step do
           step_container do
-            render Docs::TailwindConfig.new
+            Text(size: "4", weight: "semibold") do
+              "Include RubyUI kit in your base component"
+            end
+
+            Text do
+              plain "Include "
+              InlineCode(class: "whitespace-nowrap") { "RubyUI" }
+              plain " module in "
+              InlineCode(class: "whitespace-nowrap") { "app/components/base.rb" }
+            end
+
+            code = <<~RUBY
+              module Components
+                class Base < Phlex::HTML
+                  include Components
+                  include RubyUI
+
+                  ...
+            RUBY
+            div(class: "w-full") do
+              Codeblock(code, syntax: :ruby)
+            end
           end
         end
 
-        # STEP 3
         steps.add_step do
           step_container do
-            render Docs::TailwindCss.new
+            Text(size: "4", weight: "semibold") do
+              "Create the RubyUI base component"
+            end
+
+            Text do
+              plain "Every RubyUI component inherit from RubyUI::Base "
+            end
+
+            Text do
+              plain "Copy and paste the code snippet below into the "
+              InlineCode(class: "whitespace-nowrap") { "app/components/ruby_ui/base.rb" }
+              plain " file."
+            end
+
+            code = <<~RUBY
+              require "tailwind_merge"
+
+              module RubyUI
+                class Base < Phlex::HTML
+                  TAILWIND_MERGER = ::TailwindMerge::Merger.new.freeze unless defined?(TAILWIND_MERGER)
+
+                  attr_reader :attrs
+
+                  def initialize(**user_attrs)
+                    @attrs = mix(default_attrs, user_attrs)
+                    @attrs[:class] = TAILWIND_MERGER.merge(@attrs[:class]) if @attrs[:class]
+                  end
+
+                  private
+
+                  def default_attrs
+                    {}
+                  end
+                end
+              end
+            RUBY
+            div(class: "w-full") do
+              Codeblock(code, syntax: :ruby)
+            end
+          end
+        end
+
+        steps.add_step do
+          step_container do
+            Text(size: "4", weight: "semibold") do
+              "Include RubyUI styles in your CSS"
+            end
+
+            Text do
+              plain "Include RubyUI styles in "
+              InlineCode(class: "whitespace-nowrap") { "app/assets/stylesheets/application.tailwind.css" }
+            end
+
+            Text do
+              "Your CSS file will look like this:"
+            end
+
+            code = <<~STYLESHEET
+              @tailwind base;
+              @tailwind components;
+              @tailwind utilities;
+
+              @layer base {
+                :root {
+                  --background: 0 0% 100%;
+                  --foreground: 240 10% 3.9%;
+                  --card: 0 0% 100%;
+                  --card-foreground: 240 10% 3.9%;
+                  --popover: 0 0% 100%;
+                  --popover-foreground: 240 10% 3.9%;
+                  --primary: 240 5.9% 10%;
+                  --primary-foreground: 0 0% 98%;
+                  --secondary: 240 4.8% 95.9%;
+                  --secondary-foreground: 240 5.9% 10%;
+                  --muted: 240 4.8% 95.9%;
+                  --muted-foreground: 240 3.8% 46.1%;
+                  --accent: 240 4.8% 95.9%;
+                  --accent-foreground: 240 5.9% 10%;
+                  --destructive: 0 84.2% 60.2%;
+                  --destructive-foreground: 0 0% 98%;
+                  --border: 240 5.9% 90%;
+                  --input: 240 5.9% 90%;
+                  --ring: 240 5.9% 10%;
+                  --radius: 0.5rem;
+
+                  /* ruby_ui especific */
+                  --warning: 38 92% 50%;
+                  --warning-foreground: 0 0% 100%;
+                  --success: 87 100% 37%;
+                  --success-foreground: 0 0% 100%;
+                }
+
+                .dark {
+                  --background: 240 10% 3.9%;
+                  --foreground: 0 0% 98%;
+                  --card: 240 10% 3.9%;
+                  --card-foreground: 0 0% 98%;
+                  --popover: 240 10% 3.9%;
+                  --popover-foreground: 0 0% 98%;
+                  --primary: 0 0% 98%;
+                  --primary-foreground: 240 5.9% 10%;
+                  --secondary: 240 3.7% 15.9%;
+                  --secondary-foreground: 0 0% 98%;
+                  --muted: 240 3.7% 15.9%;
+                  --muted-foreground: 240 5% 64.9%;
+                  --accent: 240 3.7% 15.9%;
+                  --accent-foreground: 0 0% 98%;
+                  --destructive: 0 62.8% 30.6%;
+                  --destructive-foreground: 0 0% 98%;
+                  --border: 240 3.7% 15.9%;
+                  --input: 240 3.7% 15.9%;
+                  --ring: 240 4.9% 83.9%;
+
+                  /* ruby_ui especific */
+                  --warning: 38 92% 50%;
+                  --warning-foreground: 0 0% 100%;
+                  --success: 84 81% 44%;
+                  --success-foreground: 0 0% 100%;
+                }
+              }
+
+              @layer base {
+                * {
+                  @apply border-border;
+                }
+
+                body {
+                  @apply bg-background text-foreground;
+                  font-feature-settings: "rlig" 1, "calt" 1;
+
+                  /* docs specific */
+                  /* https://css-tricks.com/snippets/css/system-font-stack/ */
+                  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+                }
+              }
+
+            STYLESHEET
+
+            div(class: "w-full") do
+              Codeblock(code, syntax: :css)
+            end
+          end
+        end
+
+        steps.add_step do
+          step_container do
+            Text(size: "4", weight: "semibold") do
+              "Install tailwindcss-animate plugin"
+            end
+
+            Text do
+              plain "Some RubyUI components utilize CSS animations to create smooth transitions."
+            end
+
+            code = <<~CODE
+              bin/importmap pin tailwindcss-animate
+            CODE
+            div(class: "w-full") do
+              Codeblock(code, syntax: :javascript)
+            end
+          end
+        end
+
+        steps.add_step do
+          step_container do
+            Text(size: "4", weight: "semibold") do
+              "Include RubyUI TailwindCSS theme"
+            end
+
+            Text do
+              plain "Include RubyUI theme config in "
+              InlineCode(class: "whitespace-nowrap") { "config/tailwind.config.js" }
+            end
+
+            Text do
+              "Your config file will look like this:"
+            end
+
+            code = <<~JAVASCRIPT
+              const defaultTheme = require('tailwindcss/defaultTheme')
+
+              module.exports = {
+                content: [
+                  './app/views/**/*.rb', // Phlex views
+                  './app/components/**/*.rb', // Phlex components
+                  './public/*.html',
+                  './app/helpers/**/*.rb',
+                  './app/javascript/**/*.js',
+                  './app/views/**/*.{erb,haml,html,slim}'
+                ],
+                darkMode: ["class"],
+                theme: {
+                  container: {
+                    center: true,
+                    padding: "2rem",
+                    screens: {
+                      "2xl": "1400px",
+                    },
+                  },
+                  extend: {
+                    colors: {
+                      border: "hsl(var(--border))",
+                      input: "hsl(var(--input))",
+                      ring: "hsl(var(--ring))",
+                      background: "hsl(var(--background))",
+                      foreground: "hsl(var(--foreground))",
+                      primary: {
+                        DEFAULT: "hsl(var(--primary))",
+                        foreground: "hsl(var(--primary-foreground))",
+                      },
+                      secondary: {
+                        DEFAULT: "hsl(var(--secondary))",
+                        foreground: "hsl(var(--secondary-foreground))",
+                      },
+                      destructive: {
+                        DEFAULT: "hsl(var(--destructive))",
+                        foreground: "hsl(var(--destructive-foreground))",
+                      },
+                      muted: {
+                        DEFAULT: "hsl(var(--muted))",
+                        foreground: "hsl(var(--muted-foreground))",
+                      },
+                      accent: {
+                        DEFAULT: "hsl(var(--accent))",
+                        foreground: "hsl(var(--accent-foreground))",
+                      },
+                      popover: {
+                        DEFAULT: "hsl(var(--popover))",
+                        foreground: "hsl(var(--popover-foreground))",
+                      },
+                      card: {
+                        DEFAULT: "hsl(var(--card))",
+                        foreground: "hsl(var(--card-foreground))",
+                      },
+                      /* ruby_ui especific */
+                      warning: {
+                        DEFAULT: "hsl(var(--warning))",
+                        foreground: "hsl(var(--warning-foreground))",
+                      },
+                      success: {
+                        DEFAULT: "hsl(var(--success))",
+                        foreground: "hsl(var(--success-foreground))",
+                      },
+                    },
+                    borderRadius: {
+                      lg: `var(--radius)`,
+                      md: `calc(var(--radius) - 2px)`,
+                      sm: "calc(var(--radius) - 4px)",
+                    },
+                    fontFamily: {
+                      sans: ["var(--font-sans)", ...defaultTheme.fontFamily.sans],
+                    },
+                  },
+                },
+                plugins: [
+                  require('@tailwindcss/forms'),
+                  require('@tailwindcss/typography'),
+                  require('@tailwindcss/container-queries'),
+                  require("../vendor/javascript/tailwindcss-animate")
+                ]
+              }
+
+            JAVASCRIPT
+
+            div(class: "w-full") do
+              Codeblock(code, syntax: :javascript)
+            end
           end
         end
       end
@@ -138,36 +448,6 @@ class Docs::Installation::RailsImportmapsView < ApplicationView
 
   def step_container(&)
     div(class: "space-y-4", &)
-  end
-
-  def js_installation
-    render Steps::Builder.new do |steps|
-      # STEP 1
-      steps.add_step do
-        step_container do
-          Text(size: "4", weight: "semibold") { "Install package" }
-          Text { "Run the following in the terminal to install RubyUI JS package" }
-          code = <<~CODE
-            bin/importmap pin ruby_ui_js
-          CODE
-          Codeblock(code, syntax: :javascript)
-        end
-      end
-
-      # STEP 2
-      steps.add_step do
-        Text(size: "4", weight: "semibold") { "Import package" }
-        Text do
-          plain "Import the package in your "
-          InlineCode(class: "whitespace-nowrap") { "app/javascript/application.js" }
-          plain " file"
-        end
-        code = <<~CODE
-          import 'ruby_ui_js';
-        CODE
-        Codeblock(code, syntax: :javascript)
-      end
-    end
   end
 
   def info_icon
@@ -182,41 +462,6 @@ class Docs::Installation::RailsImportmapsView < ApplicationView
         d:
           "M2.25 12c0-5.385 4.365-9.75 9.75-9.75s9.75 4.365 9.75 9.75-4.365 9.75-9.75 9.75S2.25 17.385 2.25 12zm8.706-1.442c1.146-.573 2.437.463 2.126 1.706l-.709 2.836.042-.02a.75.75 0 01.67 1.34l-.04.022c-1.147.573-2.438-.463-2.127-1.706l.71-2.836-.042.02a.75.75 0 11-.671-1.34l.041-.022zM12 9a.75.75 0 100-1.5.75.75 0 000 1.5z",
         clip_rule: "evenodd"
-      )
-    end
-  end
-
-  def arrow_icon
-    svg(
-      xmlns: "http://www.w3.org/2000/svg",
-      fill: "none",
-      viewbox: "0 0 24 24",
-      stroke_width: "2",
-      stroke: "currentColor",
-      class: "w-4 h-4 ml-1.5 -mr-1"
-    ) do |s|
-      s.path(
-        stroke_linecap: "round",
-        stroke_linejoin: "round",
-        d: "M4.5 12h15m0 0l-6.75-6.75M19.5 12l-6.75 6.75"
-      )
-    end
-  end
-
-  def alert_icon
-    svg(
-      xmlns: "http://www.w3.org/2000/svg",
-      fill: "none",
-      viewbox: "0 0 24 24",
-      stroke_width: "1.5",
-      stroke: "currentColor",
-      class: "w-5 h-5"
-    ) do |s|
-      s.path(
-        stroke_linecap: "round",
-        stroke_linejoin: "round",
-        d:
-          "M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"
       )
     end
   end


### PR DESCRIPTION
Add updated instructions to importmap installation doc page. In the future we can extract some shared sections between jsbundling page and importmaps page and reuse them.