### PR TITLE
Upgrade phlex and phlex-rails to 2.0.2 version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 GIT
   remote: https://github.com/phlex-ruby/phlex-rails.git
-  revision: 80388e7c1a5ba53f11e8de45eeb250bb99bc9060
+  revision: be91ab54bc1b0497e4cc72f1f435524811e0be76
   specs:
-    phlex-rails (2.0.0.beta2)
-      phlex (= 2.0.0.beta2)
+    phlex-rails (2.0.2)
+      phlex (~> 2.0.2)
       railties (>= 6.1, < 9)
 
 GIT
   remote: https://github.com/phlex-ruby/phlex.git
-  revision: f02859abaf1397d4df37c23b12646d47a55e5b46
+  revision: bdff5f6800d36717bd576c8af8331ebeca8b4b3b
   specs:
-    phlex (2.0.0.beta2)
+    phlex (2.0.2)
 
 GIT
   remote: https://github.com/ruby-ui/ruby_ui.git

--- a/app/components/component_setup/tabs.rb
+++ b/app/components/component_setup/tabs.rb
@@ -12,7 +12,7 @@ module Components
       def view_template
         Heading(level: 2) { "Installation" }
 
-        Tabs(default_value: "cli", class: "w-full") do
+        RubyUI::Tabs(default_value: "cli", class: "w-full") do
           TabsList do
             TabsTrigger(value: "cli") { "CLI" }
             TabsTrigger(value: "manual") { "Manual" }


### PR DESCRIPTION
I upgraded the Phlex gem to version 2.0.2, but during the process, the tests started failing with the error:

> missing keyword "component_name"

This occurred when rendering the Tabs component. 

After some investigation, I discovered that the internal Tabs component used within the main component requires the RubyUI module to be explicitly specified.

