### PR TITLE
Remove 'helpers' prefix

### DIFF
--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -7,8 +7,7 @@ class Components::Base < Phlex::HTML
   include Phlex::Rails::Helpers::ImagePath
   include Phlex::Rails::Helpers::ImageURL
   include Phlex::Rails::Helpers::Flash
-
-  register_value_helper :request
+  include Phlex::Rails::Helpers::Request
 
   TAILWIND_MERGER = ::TailwindMerge::Merger.new.freeze unless defined?(TAILWIND_MERGER)
 

--- a/app/components/base.rb
+++ b/app/components/base.rb
@@ -4,6 +4,11 @@ class Components::Base < Phlex::HTML
 
   # Include any helpers you want to be available across all components
   include Phlex::Rails::Helpers::Routes
+  include Phlex::Rails::Helpers::ImagePath
+  include Phlex::Rails::Helpers::ImageURL
+  include Phlex::Rails::Helpers::Flash
+
+  register_value_helper :request
 
   TAILWIND_MERGER = ::TailwindMerge::Merger.new.freeze unless defined?(TAILWIND_MERGER)
 

--- a/app/views/components/shared/logo.rb
+++ b/app/views/components/shared/logo.rb
@@ -2,10 +2,10 @@
 
 class Shared::Logo < ApplicationComponent
   def view_template
-    a(href: helpers.root_url, class: "mr-6 flex items-center space-x-2") do
+    a(href: root_url, class: "mr-6 flex items-center space-x-2") do
       Heading(level: 4, class: "flex items-center") {
-        img(src: helpers.image_url("logo.svg"), class: "h-4 block dark:hidden")
-        img(src: helpers.image_url("logo_dark.svg"), class: "h-4 hidden dark:block")
+        img(src: image_url("logo.svg"), class: "h-4 block dark:hidden")
+        img(src: image_url("logo_dark.svg"), class: "h-4 hidden dark:block")
         span(class: "sr-only") { "RubyUI" }
         Badge(variant: :amber, size: :sm, class: "ml-2 whitespace-nowrap") { "Pre Release" }
       }

--- a/app/views/components/shared/menu.rb
+++ b/app/views/components/shared/menu.rb
@@ -5,9 +5,9 @@ class Shared::Menu < ApplicationComponent
     div(class: "pb-4") do
       # Main routes (Docs, Components, Themes, Github, Discord, Twitter)
       div(class: "md:hidden") do
-        main_link("Docs", helpers.docs_introduction_path)
-        main_link("Components", helpers.docs_accordion_path)
-        main_link("Themes", helpers.theme_path("default"))
+        main_link("Docs", docs_introduction_path)
+        main_link("Components", docs_accordion_path)
+        main_link("Themes", theme_path("default"))
         main_link("Github", "https://github.com/PhlexUI/phlex_ui")
         main_link("Discord", ENV["DISCORD_INVITE_LINK"])
         main_link("Twitter", ENV["PHLEXUI_TWITTER_LINK"])
@@ -44,70 +44,70 @@ class Shared::Menu < ApplicationComponent
 
   def getting_started_links
     [
-      {name: "Introduction", path: helpers.docs_introduction_path},
-      {name: "Installation", path: helpers.docs_installation_path},
-      {name: "Dark mode", path: helpers.docs_dark_mode_path},
-      {name: "Theming", path: helpers.docs_theming_path},
-      {name: "Customizing components", path: helpers.docs_customizing_components_path}
+      {name: "Introduction", path: docs_introduction_path},
+      {name: "Installation", path: docs_installation_path},
+      {name: "Dark mode", path: docs_dark_mode_path},
+      {name: "Theming", path: docs_theming_path},
+      {name: "Customizing components", path: docs_customizing_components_path}
     ]
   end
 
   def installation_links
     [
-      {name: "Rails - JS Bundler", path: helpers.docs_installation_rails_bundler_path},
-      {name: "Rails - Importmaps", path: helpers.docs_installation_rails_importmaps_path}
+      {name: "Rails - JS Bundler", path: docs_installation_rails_bundler_path},
+      {name: "Rails - Importmaps", path: docs_installation_rails_importmaps_path}
     ]
   end
 
   def components
     [
-      {name: "Accordion", path: helpers.docs_accordion_path},
-      {name: "Alert", path: helpers.docs_alert_path},
-      {name: "Alert Dialog", path: helpers.docs_alert_dialog_path},
-      {name: "Aspect Ratio", path: helpers.docs_aspect_ratio_path},
-      {name: "Avatar", path: helpers.docs_avatar_path},
-      {name: "Badge", path: helpers.docs_badge_path},
-      {name: "Breadcrumb", path: helpers.docs_breadcrumb_path, badge: "New"},
-      {name: "Button", path: helpers.docs_button_path},
-      {name: "Calendar", path: helpers.docs_calendar_path},
-      {name: "Card", path: helpers.docs_card_path},
-      # { name: "Chart", path: helpers.docs_chart_path, badge: "New" },
-      {name: "Checkbox", path: helpers.docs_checkbox_path},
-      {name: "Checkbox Group", path: helpers.docs_checkbox_group_path},
-      {name: "Clipboard", path: helpers.docs_clipboard_path},
-      {name: "Codeblock", path: helpers.docs_codeblock_path},
-      {name: "Collapsible", path: helpers.docs_collapsible_path},
-      {name: "Combobox", path: helpers.docs_combobox_path, badge: "Updated"},
-      {name: "Command", path: helpers.docs_command_path},
-      {name: "Context Menu", path: helpers.docs_context_menu_path},
-      {name: "Date Picker", path: helpers.docs_date_picker_path},
-      {name: "Dialog / Modal", path: helpers.docs_dialog_path},
-      {name: "Dropdown Menu", path: helpers.docs_dropdown_menu_path},
-      {name: "Form", path: helpers.docs_form_path},
-      {name: "Hover Card", path: helpers.docs_hover_card_path},
-      {name: "Input", path: helpers.docs_input_path},
-      {name: "Link", path: helpers.docs_link_path},
-      {name: "Masked Input", path: helpers.masked_input_path},
-      {name: "Pagination", path: helpers.docs_pagination_path, badge: "New"},
-      {name: "Popover", path: helpers.docs_popover_path},
-      {name: "Progress", path: helpers.docs_progress_path, badge: "New"},
-      {name: "Radio Button", path: helpers.docs_radio_button_path, badge: "New"},
-      {name: "Select", path: helpers.docs_select_path, badge: "New"},
-      {name: "Sheet", path: helpers.docs_sheet_path},
-      {name: "Shortcut Key", path: helpers.docs_shortcut_key_path},
-      {name: "Skeleton", path: helpers.docs_skeleton_path, badge: "New"},
-      {name: "Switch", path: helpers.docs_switch_path},
-      {name: "Table", path: helpers.docs_table_path},
-      {name: "Tabs", path: helpers.docs_tabs_path},
-      {name: "Textarea", path: helpers.docs_textarea_path},
-      {name: "Theme Toggle", path: helpers.docs_theme_toggle_path},
-      {name: "Tooltip", path: helpers.docs_tooltip_path},
-      {name: "Typography", path: helpers.docs_typography_path}
+      {name: "Accordion", path: docs_accordion_path},
+      {name: "Alert", path: docs_alert_path},
+      {name: "Alert Dialog", path: docs_alert_dialog_path},
+      {name: "Aspect Ratio", path: docs_aspect_ratio_path},
+      {name: "Avatar", path: docs_avatar_path},
+      {name: "Badge", path: docs_badge_path},
+      {name: "Breadcrumb", path: docs_breadcrumb_path, badge: "New"},
+      {name: "Button", path: docs_button_path},
+      {name: "Calendar", path: docs_calendar_path},
+      {name: "Card", path: docs_card_path},
+      # { name: "Chart", path: docs_chart_path, badge: "New" },
+      {name: "Checkbox", path: docs_checkbox_path},
+      {name: "Checkbox Group", path: docs_checkbox_group_path},
+      {name: "Clipboard", path: docs_clipboard_path},
+      {name: "Codeblock", path: docs_codeblock_path},
+      {name: "Collapsible", path: docs_collapsible_path},
+      {name: "Combobox", path: docs_combobox_path, badge: "Updated"},
+      {name: "Command", path: docs_command_path},
+      {name: "Context Menu", path: docs_context_menu_path},
+      {name: "Date Picker", path: docs_date_picker_path},
+      {name: "Dialog / Modal", path: docs_dialog_path},
+      {name: "Dropdown Menu", path: docs_dropdown_menu_path},
+      {name: "Form", path: docs_form_path},
+      {name: "Hover Card", path: docs_hover_card_path},
+      {name: "Input", path: docs_input_path},
+      {name: "Link", path: docs_link_path},
+      {name: "Masked Input", path: masked_input_path},
+      {name: "Pagination", path: docs_pagination_path, badge: "New"},
+      {name: "Popover", path: docs_popover_path},
+      {name: "Progress", path: docs_progress_path, badge: "New"},
+      {name: "Radio Button", path: docs_radio_button_path, badge: "New"},
+      {name: "Select", path: docs_select_path, badge: "New"},
+      {name: "Sheet", path: docs_sheet_path},
+      {name: "Shortcut Key", path: docs_shortcut_key_path},
+      {name: "Skeleton", path: docs_skeleton_path, badge: "New"},
+      {name: "Switch", path: docs_switch_path},
+      {name: "Table", path: docs_table_path},
+      {name: "Tabs", path: docs_tabs_path},
+      {name: "Textarea", path: docs_textarea_path},
+      {name: "Theme Toggle", path: docs_theme_toggle_path},
+      {name: "Tooltip", path: docs_tooltip_path},
+      {name: "Typography", path: docs_typography_path}
     ]
   end
 
   def menu_link(component)
-    current_path = component[:path] == helpers.request.path
+    current_path = component[:path] == request.path
     a(
       href: component[:path],
       class: [
@@ -123,7 +123,7 @@ class Shared::Menu < ApplicationComponent
   end
 
   def main_link(name, path)
-    current_path = path == helpers.request.path
+    current_path = path == request.path
     a(
       href: path,
       class: [

--- a/app/views/components/shared/navbar.rb
+++ b/app/views/components/shared/navbar.rb
@@ -8,9 +8,9 @@ class Shared::Navbar < ApplicationComponent
           render Shared::MobileMenu.new(class: "md:hidden")
           render Shared::Logo.new
 
-          Link(href: helpers.docs_introduction_path, variant: :ghost, class: "hidden md:inline-block") { "Docs" }
-          Link(href: helpers.docs_accordion_path, variant: :ghost, class: "hidden md:inline-block") { "Components" }
-          Link(href: helpers.theme_path("default"), variant: :ghost, class: "hidden md:inline-block") { "Themes" }
+          Link(href: docs_introduction_path, variant: :ghost, class: "hidden md:inline-block") { "Docs" }
+          Link(href: docs_accordion_path, variant: :ghost, class: "hidden md:inline-block") { "Components" }
+          Link(href: theme_path("default"), variant: :ghost, class: "hidden md:inline-block") { "Themes" }
         end
         div(class: "flex items-center gap-x-2 md:divide-x") do
           div(class: "flex items-center") do

--- a/app/views/docs/aspect_ratio_view.rb
+++ b/app/views/docs/aspect_ratio_view.rb
@@ -14,8 +14,7 @@ class Docs::AspectRatioView < ApplicationView
             img(
               alt: "Placeholder",
               loading: "lazy",
-              src:
-                helpers.image_path('pattern.jpg')
+              src: image_path('pattern.jpg')
             )
           end
         RUBY
@@ -27,8 +26,7 @@ class Docs::AspectRatioView < ApplicationView
             img(
               alt: "Placeholder",
               loading: "lazy",
-              src:
-                helpers.image_path('pattern.jpg')
+              src: image_path('pattern.jpg')
             )
           end
         RUBY
@@ -40,8 +38,7 @@ class Docs::AspectRatioView < ApplicationView
             img(
               alt: "Placeholder",
               loading: "lazy",
-              src:
-                helpers.image_path('pattern.jpg')
+              src: image_path('pattern.jpg')
             )
           end
         RUBY
@@ -53,8 +50,7 @@ class Docs::AspectRatioView < ApplicationView
             img(
               alt: "Placeholder",
               loading: "lazy",
-              src:
-                helpers.image_path('pattern.jpg')
+              src: image_path('pattern.jpg')
             )
           end
         RUBY

--- a/app/views/docs/card_view.rb
+++ b/app/views/docs/card_view.rb
@@ -20,8 +20,7 @@ class Docs::CardView < ApplicationView
                 img(
                   alt: "Placeholder",
                   loading: "lazy",
-                  src:
-                    helpers.image_url('pattern.jpg')
+                  src: image_url('pattern.jpg')
                 )
               end
             end
@@ -40,8 +39,7 @@ class Docs::CardView < ApplicationView
               img(
                 alt: "Placeholder",
                 loading: "lazy",
-                src:
-                  helpers.image_url('pattern.jpg')
+                src: image_url('pattern.jpg')
               )
             end
             CardHeader do

--- a/app/views/docs/command_view.rb
+++ b/app/views/docs/command_view.rb
@@ -135,12 +135,12 @@ class Docs::CommandView < ApplicationView
 
   def components_list
     [
-      {name: "Accordion", path: helpers.docs_accordion_path},
-      {name: "Alert", path: helpers.docs_alert_path},
-      {name: "Alert Dialog", path: helpers.docs_alert_dialog_path},
-      {name: "Aspect Ratio", path: helpers.docs_aspect_ratio_path},
-      {name: "Avatar", path: helpers.docs_avatar_path},
-      {name: "Badge", path: helpers.docs_badge_path}
+      {name: "Accordion", path: docs_accordion_path},
+      {name: "Alert", path: docs_alert_path},
+      {name: "Alert Dialog", path: docs_alert_dialog_path},
+      {name: "Aspect Ratio", path: docs_aspect_ratio_path},
+      {name: "Avatar", path: docs_avatar_path},
+      {name: "Badge", path: docs_badge_path}
     ]
   end
 

--- a/app/views/docs/dialog_view.rb
+++ b/app/views/docs/dialog_view.rb
@@ -25,8 +25,7 @@ class Docs::DialogView < ApplicationView
                   img(
                     alt: "Placeholder",
                     loading: "lazy",
-                    src:
-                      helpers.image_path("pattern.jpg")
+                    src: image_path("pattern.jpg")
                   )
                 end
               end
@@ -56,8 +55,7 @@ class Docs::DialogView < ApplicationView
                     img(
                       alt: "Placeholder",
                       loading: "lazy",
-                      src:
-                        helpers.image_path("pattern.jpg")
+                      src: image_path("pattern.jpg")
                     )
                   end
                 end
@@ -82,8 +80,7 @@ class Docs::DialogView < ApplicationView
                     img(
                       alt: "Placeholder",
                       loading: "lazy",
-                      src:
-                        helpers.image_path("pattern.jpg")
+                      src: image_path("pattern.jpg")
                     )
                   end
                 end

--- a/app/views/docs/getting_started/installation_view.rb
+++ b/app/views/docs/getting_started/installation_view.rb
@@ -9,8 +9,8 @@ class Docs::GettingStarted::InstallationView < ApplicationView
 
       Heading(level: 2) { "Select a Framework" }
       div(class: "grid grid-cols-1 sm:grid-cols-2 gap-4") do
-        framework_card(title: "Rails --- JS Bundler", link: helpers.docs_installation_rails_bundler_path) { rails_logo }
-        framework_card(title: "Rails --- Importmaps", link: helpers.docs_installation_rails_importmaps_path) { rails_logo }
+        framework_card(title: "Rails --- JS Bundler", link: docs_installation_rails_bundler_path) { rails_logo }
+        framework_card(title: "Rails --- Importmaps", link: docs_installation_rails_importmaps_path) { rails_logo }
       end
     end
   end

--- a/app/views/docs/typography_view.rb
+++ b/app/views/docs/typography_view.rb
@@ -43,7 +43,7 @@ class Docs::TypographyView < ComponentView
         <<~RUBY
           Text(class: 'text-center') do
             plain "Checkout our "
-            InlineLink(href: helpers.docs_installation_path) { "installation instructions" }
+            InlineLink(href: docs_installation_path) { "installation instructions" }
             plain " to get started."
           end
         RUBY

--- a/app/views/errors/internal_server_error_view.rb
+++ b/app/views/errors/internal_server_error_view.rb
@@ -9,7 +9,7 @@ class Errors::InternalServerErrorView < ApplicationView
         Text(class: "text-muted-foreground") { "Something unexpected happened. We're looking into it." }
       end
 
-      Link(href: helpers.root_path, variant: :primary, class: "w-full") do
+      Link(href: root_path, variant: :primary, class: "w-full") do
         house_icon
         plain "Go to home"
       end

--- a/app/views/errors/not_found_view.rb
+++ b/app/views/errors/not_found_view.rb
@@ -9,7 +9,7 @@ class Errors::NotFoundView < ApplicationView
         Text(class: "text-muted-foreground") { "The page you were looking for doesn't exist." }
       end
 
-      Link(href: helpers.root_path, variant: :primary, class: "w-full") do
+      Link(href: root_path, variant: :primary, class: "w-full") do
         house_icon
         plain "Go to home"
       end

--- a/app/views/layouts/application_layout.rb
+++ b/app/views/layouts/application_layout.rb
@@ -12,7 +12,7 @@ class ApplicationLayout < ApplicationView
       body do
         render Shared::Navbar.new
         main(&block)
-        render Shared::Flashes.new(notice: helpers.flash[:notice], alert: helpers.flash[:alert])
+        render Shared::Flashes.new(notice: flash[:notice], alert: flash[:alert])
       end
     end
   end

--- a/app/views/layouts/docs_layout.rb
+++ b/app/views/layouts/docs_layout.rb
@@ -19,7 +19,7 @@ class DocsLayout < ApplicationView
             end
           end
         end
-        render Shared::Flashes.new(notice: helpers.flash[:notice], alert: helpers.flash[:alert])
+        render Shared::Flashes.new(notice: flash[:notice], alert: flash[:alert])
       end
     end
   end

--- a/app/views/layouts/errors_layout.rb
+++ b/app/views/layouts/errors_layout.rb
@@ -16,7 +16,7 @@ class ErrorsLayout < ApplicationView
           render Shared::Logo.new
           div(class: "container w-full max-w-md", &block)
         end
-        render Shared::Flashes.new(notice: helpers.flash[:notice], alert: helpers.flash[:alert])
+        render Shared::Flashes.new(notice: flash[:notice], alert: flash[:alert])
       end
     end
   end

--- a/app/views/layouts/mailer_layout.rb
+++ b/app/views/layouts/mailer_layout.rb
@@ -275,7 +275,7 @@ class MailerLayout < Phlex::HTML
 
                 div(class: "logo-container") do
                   a(href: ENV["HOST"]) do
-                    img(src: helpers.image_url("logo.svg"), alt: ENV["APP_NAME"], height: "20")
+                    img(src: image_url("logo.svg"), alt: ENV["APP_NAME"], height: "20")
                   end
                 end
 

--- a/app/views/layouts/pages_layout.rb
+++ b/app/views/layouts/pages_layout.rb
@@ -12,7 +12,7 @@ class PagesLayout < ApplicationView
       body do
         render Shared::Navbar.new
         main(class: "relative", &block)
-        render Shared::Flashes.new(notice: helpers.flash[:notice], alert: helpers.flash[:alert])
+        render Shared::Flashes.new(notice: flash[:notice], alert: flash[:alert])
       end
     end
   end

--- a/app/views/pages/home_view.rb
+++ b/app/views/pages/home_view.rb
@@ -4,8 +4,8 @@ class Pages::HomeView < ApplicationView
   def view_template
     render HomeView::Banner.new do |banner|
       banner.cta do
-        Link(variant: :outline, href: helpers.docs_accordion_path, class: "text-center justify-center") { "Browse Components" }
-        Link(variant: :primary, href: helpers.docs_introduction_path, class: "text-center justify-center") do
+        Link(variant: :outline, href: docs_accordion_path, class: "text-center justify-center") { "Browse Components" }
+        Link(variant: :primary, href: docs_introduction_path, class: "text-center justify-center") do
           plain "Get Started"
           svg(
             xmlns: "http://www.w3.org/2000/svg",

--- a/app/views/themes/customize_popover.rb
+++ b/app/views/themes/customize_popover.rb
@@ -31,7 +31,7 @@ module Themes
     private
 
     def render_color_picker(name, color_hash, selected: false)
-      Link(href: helpers.theme_path(name&.downcase), variant: :outline, class: ["!justify-start", ("ring-neutral-950 ring-1" if selected)]) do
+      Link(href: theme_path(name&.downcase), variant: :outline, class: ["!justify-start", ("ring-neutral-950 ring-1" if selected)]) do
         div(class: "w-4 h-4 rounded-full shrink-0 mr-2 ring-white dark:hidden", style: "background-color: hsl(#{color_hash[:root][:primary].split.join(",")})") do
         end
         div(class: "w-4 h-4 rounded-full shrink-0 mr-2 ring-white hidden dark:block", style: "background-color: hsl(#{color_hash[:dark][:primary].split.join(",")})") do

--- a/app/views/themes/grid/card.rb
+++ b/app/views/themes/grid/card.rb
@@ -12,8 +12,7 @@ module Themes
               img(
                 alt: "Placeholder",
                 loading: "lazy",
-                src:
-                  helpers.image_url("pattern.jpg")
+                src: image_url("pattern.jpg")
               )
             end
           end

--- a/app/views/themes/grid/command.rb
+++ b/app/views/themes/grid/command.rb
@@ -97,12 +97,12 @@ module Themes
 
       def components_list
         [
-          {name: "Accordion", path: helpers.docs_accordion_path},
-          {name: "Alert", path: helpers.docs_alert_path},
-          {name: "Alert Dialog", path: helpers.docs_alert_dialog_path},
-          {name: "Aspect Ratio", path: helpers.docs_aspect_ratio_path},
-          {name: "Avatar", path: helpers.docs_avatar_path},
-          {name: "Badge", path: helpers.docs_badge_path}
+          {name: "Accordion", path: docs_accordion_path},
+          {name: "Alert", path: docs_alert_path},
+          {name: "Alert Dialog", path: docs_alert_dialog_path},
+          {name: "Aspect Ratio", path: docs_aspect_ratio_path},
+          {name: "Avatar", path: docs_avatar_path},
+          {name: "Badge", path: docs_badge_path}
         ]
       end
 


### PR DESCRIPTION
We received the following warning from Phlex:

```
The `helpers` method is deprecated and will be removed in the next
minor version of phlex-rails.

If you absolutely need to access the underlying Rails view context,
you can do that via the `view_context` method, though this is
not recommended.

It is much safer to use one of the built-in helper adapters or to
register your own adapter via `register_output_helper` or
`register_value_helper`.

See https://beta.phlex.fun/rails/helpers.html
```
To address this, I have adapted the code to be compatible with the next version, ensuring we follow the recommended practices and avoid future issues with the deprecation of the `helpers` method.