### PR TITLE
fix Glitch in the sidebar during navigation

### DIFF
--- a/app/javascript/controllers/sidebar_menu_controller.js
+++ b/app/javascript/controllers/sidebar_menu_controller.js
@@ -3,11 +3,14 @@ import { Controller } from "@hotwired/stimulus"
 // Connects to data-controller="sidebar-menu"
 export default class extends Controller {
   connect() {
-    window.addEventListener("turbo:before-visit", () => {
+    window.addEventListener("turbo:before-cache", () => {
       localStorage.setItem("menuScrollPositon", this.element.scrollTop);
     });
 
-    window.addEventListener("turbo:load", () => {
+    window.addEventListener("turbo:before-render", () => {
+      this.element.scrollTop = localStorage.getItem("menuScrollPositon") || 0;
+    });
+    window.addEventListener("turbo:render", () => {
       this.element.scrollTop = localStorage.getItem("menuScrollPositon") || 0;
     });
   }

--- a/app/views/components/shared/head.rb
+++ b/app/views/components/shared/head.rb
@@ -14,7 +14,7 @@ class Shared::Head < ApplicationComponent
       csrf_meta_tags
       stylesheet_link_tag "https://api.fontshare.com/v2/css?f[]=general-sans@1&display=swap", data_turbo_track: "reload"
       stylesheet_link_tag "application", data_turbo_track: "reload"
-      javascript_include_tag "application", data_turbo_track: "reload", defer: true
+      javascript_include_tag "application", data_turbo_track: "reload", type: "module"
     end
   end
 end


### PR DESCRIPTION
There is a glitch occurring during navigation between components. Whenever you hover over a link to another component page, the following error is rendered:

`Uncaught (in promise) TypeError: map3.get is not a function`

After some research, I found that [changing the type attribute of the javascript_include_tag from `defer` to `module`](https://gist.github.com/pch/fe276b29ba037bdaeaa525932478ca18) resolves this issue. While this eliminates the error, the glitch persisted.

After further exploration, I followed [Konnor Rogers's approach](https://dev.to/konnorrogers/maintain-scroll-position-in-turbo-without-data-turbo-permanent-2b1i) and updated the Turbo events used in the controller. Now, the navigation is smooth without any glitches. Here's a demo:

https://github.com/user-attachments/assets/2786caa7-cde6-424f-9500-95222756a95f

