### PR TITLE
Remove ApplicationComponent

### DIFF
--- a/app/views/application_view.rb
+++ b/app/views/application_view.rb
@@ -13,7 +13,7 @@ class MethodCallFinder < Prism::Visitor
   end
 end
 
-class ApplicationView < ApplicationComponent
+class ApplicationView < Base
   include ApplicationHelper
   # The ApplicationView is an abstract class for all your views.
 

--- a/app/views/base.rb
+++ b/app/views/base.rb
@@ -1,0 +1,33 @@
+class Base < Phlex::HTML
+  include Components
+  include RubyUI
+
+  # Include any helpers you want to be available across all components
+  include Phlex::Rails::Helpers::Routes
+  include Phlex::Rails::Helpers::ImagePath
+  include Phlex::Rails::Helpers::ImageURL
+  include Phlex::Rails::Helpers::Flash
+  include Phlex::Rails::Helpers::Request
+
+  TAILWIND_MERGER = ::TailwindMerge::Merger.new.freeze unless defined?(TAILWIND_MERGER)
+
+  attr_reader :attrs
+
+  def initialize(**user_attrs)
+    @attrs = mix(default_attrs, user_attrs)
+    @attrs[:class] = TAILWIND_MERGER.merge(@attrs[:class]) if @attrs[:class]
+  end
+
+  if Rails.env.development?
+    def before_template
+      comment { "Before #{self.class.name}" }
+      super
+    end
+  end
+
+  private
+
+  def default_attrs
+    {}
+  end
+end

--- a/app/views/component_view.rb
+++ b/app/views/component_view.rb
@@ -1,4 +1,0 @@
-class ComponentView < ApplicationComponent
-  include RubyUI
-  include ApplicationHelper
-end

--- a/app/views/components/application_component.rb
+++ b/app/views/components/application_component.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class ApplicationComponent < Components::Base
-end

--- a/app/views/docs/typography_view.rb
+++ b/app/views/docs/typography_view.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Docs::TypographyView < ComponentView
+class Docs::TypographyView < ApplicationView
   def view_template
     component = "Typography"
 


### PR DESCRIPTION
To complete the component migration, I am removing the `ApplicationComponent` class. Additionally, I’ve taken the opportunity to create the `Views::Base` class, which will help us begin adhering to the `views` guidelines for Phlex 2.0