### PR TITLE
Fix typo: rils -> rails

### DIFF
--- a/app/views/docs/accordion.rb
+++ b/app/views/docs/accordion.rb
@@ -30,7 +30,7 @@ class Views::Docs::Accordion < Views::Base
             Accordion do
               AccordionItem do
                 AccordionTrigger do
-                  p(class: "font-medium") { "Can I use it with Rils?" }
+                  p(class: "font-medium") { "Can I use it with Rails?" }
                   AccordionIcon()
                 end
 


### PR DESCRIPTION
I happened to notice this while reading the public docs site earlier <3