### PR TITLE
Use devcontainers for CI workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,69 +11,49 @@ on:
 
 jobs:
   scan:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
-
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        
+      - name: Build and run dev container task
+        uses: devcontainers/ci@v0.3
         with:
-          bundler-cache: true
+          runCmd: |
+            bundle install
+            # Add scan commands here
 
   lint:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
+    
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        
+      - name: Build and run dev container task
+        uses: devcontainers/ci@v0.3
         with:
-          bundler-cache: true
-
-      - name: Lint code for consistent style
-        run: bundle exec standardrb
+          runCmd: bundle exec standardrb
 
   test:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
+    
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
+      - name: Build and run dev container task
+        uses: devcontainers/ci@v0.3
         with:
-          bundler-cache: true
-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".node-version"
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y -qq libvips
-          pnpm install
-
-      - name: Run tests
-        env:
-          RAILS_ENV: test
-          # RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-        run: |
-          bin/rails test:prepare
-          bin/rails db:test:prepare
-          bin/rails test
+          runCmd: |
+            bin/setup --skip-server
+            bin/rails test:prepare
+            bin/rails db:test:prepare
+            bin/rails test
 
   heroku-deploy:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/PhlexUI-web' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,42 +2,14 @@ name: CI
 
 on:
   pull_request:
-    branches:
-      - "*"
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
   push:
-    branches:
-      - main
-      - v1
-
+    branches: "main"
 jobs:
-  scan:
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Build and run dev container task
-        uses: devcontainers/ci@v0.3
-        with:
-          runCmd: |
-            bundle install
-            # Add scan commands here
-
-  lint:
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        
-      - name: Build and run dev container task
-        uses: devcontainers/ci@v0.3
-        with:
-          runCmd: bundle exec standardrb
-
   test:
     timeout-minutes: 15
     runs-on: ubuntu-latest
@@ -54,10 +26,11 @@ jobs:
             bin/rails test:prepare
             bin/rails db:test:prepare
             bin/rails test
+            bundle exec standardrb
 
   heroku-deploy:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/PhlexUI-web' }}
-    needs: [lint, test]
+    needs: [test]
     runs-on: ubuntu-latest
 
     steps:
@@ -72,7 +45,7 @@ jobs:
 
   fly-deploy:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    needs: [lint, test]
+    needs: [test]
     name: Deploy app
     runs-on: ubuntu-latest
     concurrency: deploy-group

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,9 @@ jobs:
   test:
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,16 +17,25 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }} 
         
       - name: Build and run dev container task
         uses: devcontainers/ci@v0.3
         with:
+          imageName: ghcr.io/ruby-ui/web-devcontainer
+          cacheFrom: ghcr.io/ruby-ui/web-devcontainer
+          push: always
           runCmd: |
-            bin/setup --skip-server
+            bundle exec standardrb
             bin/rails test:prepare
             bin/rails db:test:prepare
             bin/rails test
-            bundle exec standardrb
 
   heroku-deploy:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/PhlexUI-web' }}


### PR DESCRIPTION
This PR updates our GitHub Actions workflows to use devcontainers instead of directly setting up the environment on the runner. This approach:

- Ensures CI runs in the same environment as development
- Simplifies workflow configuration
- Reduces maintenance by centralizing environment setup in the devcontainer
- Increases CI timeout to accommodate container build time

We now have 1 ci step instead of 3, and the ci will cache the Docker image to speed up future builds. Now we can ensure that devcontainers will not be broken. 