### PR TITLE
aria-disabled for Link

### DIFF
--- a/app/components/ruby_ui/link/link.rb
+++ b/app/components/ruby_ui/link/link.rb
@@ -2,6 +2,13 @@
 
 module RubyUI
   class Link < Base
+    BASE_CLASSES = [
+      "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors",
+      "disabled:pointer-events-none disabled:opacity-50",
+      "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+      "aria-disabled:pointer-events-none aria-disabled:opacity-50 aria-disabled:cursor-not-allowed"
+    ].freeze
+
     def initialize(href: "#", variant: :link, size: :md, icon: false, **attrs)
       @href = href
       @variant = variant.to_sym
@@ -36,43 +43,54 @@ module RubyUI
 
     def primary_classes
       [
-        "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground shadow hover:bg-primary/90",
-        size_classes
+        BASE_CLASSES,
+        size_classes,
+        "bg-primary text-primary-foreground shadow",
+        "hover:bg-primary/90"
       ]
     end
 
     def link_classes
       [
-        "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-primary underline-offset-4 hover:underline",
-        size_classes
+        BASE_CLASSES,
+        size_classes,
+        "text-primary underline-offset-4",
+        "hover:underline"
       ]
     end
 
     def secondary_classes
       [
-        "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-secondary text-secondary-foreground hover:bg-opacity-80",
-        size_classes
+        BASE_CLASSES,
+        size_classes,
+        "bg-secondary text-secondary-foreground",
+        "hover:bg-opacity-80"
       ]
     end
 
     def destructive_classes
       [
-        "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
-        size_classes
+        BASE_CLASSES,
+        size_classes,
+        "bg-destructive text-destructive-foreground shadow-sm",
+        "hover:bg-destructive/90"
       ]
     end
 
     def outline_classes
       [
-        "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
-        size_classes
+        BASE_CLASSES,
+        size_classes,
+        "border border-input bg-background shadow-sm",
+        "hover:bg-accent hover:text-accent-foreground"
       ]
     end
 
     def ghost_classes
       [
-        "whitespace-nowrap inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 hover:bg-accent hover:text-accent-foreground",
-        size_classes
+        BASE_CLASSES,
+        size_classes,
+        "hover:bg-accent hover:text-accent-foreground"
       ]
     end
 
@@ -88,10 +106,7 @@ module RubyUI
     end
 
     def default_attrs
-      {
-        type: "button",
-        class: default_classes
-      }
+      {type: "button", class: default_classes}
     end
   end
 end

--- a/app/views/docs/link.rb
+++ b/app/views/docs/link.rb
@@ -15,6 +15,12 @@ class Views::Docs::Link < Views::Base
         RUBY
       end
 
+      render Docs::VisualCodeExample.new(title: "Aria Disabled", context: self) do
+        <<~RUBY
+          Link(aria: {disabled: "true"}, href: "#") { "Link" }
+        RUBY
+      end
+
       render Docs::VisualCodeExample.new(title: "Primary", description: "This is the primary variant of a Link", context: self) do
         <<~RUBY
           Link(href: "#", variant: :primary) { "Primary" }


### PR DESCRIPTION
@cirdes @stephannv

the pure `disabled` never worked for Link because the tag `a` does not accept `disabled`.
but `aria-disabled` is working pretty well.

should we accept `disabled` here?

![image](https://github.com/user-attachments/assets/3824c668-2f5f-4b31-ab57-2b43c1723af5)