### PR TITLE
aria-disabled for RadioButton

### DIFF
--- a/app/components/ruby_ui/form/form_field_label.rb
+++ b/app/components/ruby_ui/form/form_field_label.rb
@@ -9,7 +9,13 @@ module RubyUI
     private
 
     def default_attrs
-      {class: "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"}
+      {
+        class: [
+          "text-sm font-medium leading-none",
+          "peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+          "peer-aria-disabled:cursor-not-allowed peer-aria-disabled:opacity-70 peer-aria-disabled:pointer-events-none"
+        ]
+      }
     end
   end
 end

--- a/app/components/ruby_ui/radio_button/radio_button.rb
+++ b/app/components/ruby_ui/radio_button/radio_button.rb
@@ -17,7 +17,8 @@ module RubyUI
         },
         class: [
           "h-4 w-4 p-0 border-primary rounded-full flex-none",
-          "disabled:cursor-not-allowed disabled:opacity-50"
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          "aria-disabled:cursor-not-allowed aria-disabled:opacity-50 aria-disabled:pointer-events-none"
         ]
       }
     end

--- a/app/views/docs/radio_button.rb
+++ b/app/views/docs/radio_button.rb
@@ -30,7 +30,7 @@ class Views::Docs::RadioButton < Views::Base
       render Docs::VisualCodeExample.new(title: "Disabled", context: self) do
         <<~RUBY
           div(class: "flex flex-row items-center gap-2") do
-            RadioButton(id: "disabled", disabled: true)
+            RadioButton(class: "peer",id: "disabled", disabled: true)
             FormFieldLabel(for: "disabled") { "Disabled" }
           end
         RUBY

--- a/app/views/docs/radio_button.rb
+++ b/app/views/docs/radio_button.rb
@@ -27,6 +27,24 @@ class Views::Docs::RadioButton < Views::Base
         RUBY
       end
 
+      render Docs::VisualCodeExample.new(title: "Disabled", context: self) do
+        <<~RUBY
+          div(class: "flex flex-row items-center gap-2") do
+            RadioButton(id: "disabled", disabled: true)
+            FormFieldLabel(for: "disabled") { "Disabled" }
+          end
+        RUBY
+      end
+
+      render Docs::VisualCodeExample.new(title: "Aria Disabled", context: self) do
+        <<~RUBY
+          div(class: "flex flex-row items-center gap-2") do
+            RadioButton(class: "peer", id: "aria-disabled", aria: {disabled: "true"})
+            FormFieldLabel(for: "aria-disabled") { "Aria Disabled" }
+          end
+        RUBY
+      end
+
       render Components::ComponentSetup::Tabs.new(component_name: component)
 
       render Docs::ComponentsTable.new(component_files(component))


### PR DESCRIPTION
@cirdes @stephannv it is necessary to add `class: "peer"` in RadioButton to apply the `disable` styles in the FormFieldLabel... I guess we should fix it in the `ruby_ui` gem.

![image](https://github.com/user-attachments/assets/f93d3346-a63b-4462-bf39-2c1cfee9af64)