### PR TITLE
fix: datepicker not opening

### DIFF
--- a/app/views/docs/date_picker.rb
+++ b/app/views/docs/date_picker.rb
@@ -12,11 +12,11 @@ class Views::Docs::DatePicker < Views::Base
       render Docs::VisualCodeExample.new(title: "Single Date", context: self) do
         <<~RUBY
           div(class: 'space-y-4 w-[260px]') do
-            Popover(options: { trigger: 'focusin' }) do
+            Popover(options: { trigger: 'click' }) do
               PopoverTrigger(class: 'w-full') do
                 div(class: 'grid w-full max-w-sm items-center gap-1.5') do
                   label(for: "date") { "Select a date" }
-                  Input(type: 'string', placeholder: "Select a date", class: 'rounded-md border shadow', id: 'date', data_controller: 'input')
+                  Input(type: 'string', placeholder: "Select a date", class: 'rounded-md border shadow', id: 'date', data_controller: 'ruby-ui--calendar-input')
                 end
               end
               PopoverContent do


### PR DESCRIPTION
This PR aims to resolve issue https://github.com/ruby-ui/web/issues/149.

I noticed that there is no Stimulus controller named simply input, but rather ruby-ui--calendar-input.

Additionally, in [method](https://github.com/ruby-ui/ruby_ui/blob/f5a275f191c32bd50d8ab2876a32586cf9435866/lib/ruby_ui/popover/popover_controller.js#L37), there is no trigger for focusin, only for hover and click. In this PR, I set it to click.
![datepicker-fix](https://github.com/user-attachments/assets/92f155f9-7bde-41c8-bfe5-101b17056df2)

