### PR TITLE
Remove DropdownMenu example that opens on hover

### DIFF
--- a/app/views/docs/dropdown_menu.rb
+++ b/app/views/docs/dropdown_menu.rb
@@ -204,24 +204,6 @@ class Views::Docs::DropdownMenu < Views::Base
         RUBY
       end
 
-      render Docs::VisualCodeExample.new(title: "Open on hover", context: self) do
-        <<~RUBY
-          DropdownMenu(options: { trigger: "mouseenter focus" }) do
-            DropdownMenuTrigger(class: 'w-full') do
-              Button(variant: :outline) { "Open" }
-            end
-            DropdownMenuContent do
-              DropdownMenuLabel { "My Account" }
-              DropdownMenuSeparator
-              DropdownMenuItem(href: '#') { "Profile" }
-              DropdownMenuItem(href: '#') { "Billing" }
-              DropdownMenuItem(href: '#') { "Team" }
-              DropdownMenuItem(href: '#') { "Subscription" }
-            end
-          end
-        RUBY
-      end
-
       render Components::ComponentSetup::Tabs.new(component_name: component)
 
       render Docs::ComponentsTable.new(component_files(component))


### PR DESCRIPTION
I'm removing this example because it isn’t working properly and hover-based dropdowns aren’t great for [touch screen support and accessibility](https://www.reddit.com/r/Frontend/comments/1d9ifuu/nav_item_dropdown_on_hover_or_click/).

This is related to [issue #307](https://github.com/ruby-ui/ruby_ui/issues/307)

References:
[Discussion on hover vs click for dropdowns](https://www.reddit.com/r/Frontend/comments/1d9ifuu/nav_item_dropdown_on_hover_or_click/)